### PR TITLE
Add Simple Availability pattern PHP port

### DIFF
--- a/availability/simple-availability/.gitignore
+++ b/availability/simple-availability/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 /coverage/
 /.phpunit.cache/
+/.deptrac.cache
 /composer.lock
 .DS_Store
 .idea/

--- a/availability/simple-availability/.gitignore
+++ b/availability/simple-availability/.gitignore
@@ -1,0 +1,7 @@
+/vendor/
+/coverage/
+/.phpunit.cache/
+/composer.lock
+.DS_Store
+.idea/
+*.log

--- a/availability/simple-availability/README.md
+++ b/availability/simple-availability/README.md
@@ -1,0 +1,243 @@
+# Simple Availability Pattern - PHP Port
+
+A PHP 8.4 implementation of the Simple Availability pattern from the [Software Archetypes](https://github.com/Software-Archetypes/archetypes) project.
+
+## Overview
+
+The Simple Availability pattern manages asset availability through a lock-based system. Assets can be in different states (maintenance, available, locked, withdrawn) with specific rules governing state transitions.
+
+## Features
+
+- **Domain-Driven Design**: Clean separation of domain logic, application services, and infrastructure
+- **Event-Driven Architecture**: Domain events for all state changes
+- **Functional Error Handling**: Result monad for explicit success/failure handling
+- **Type Safety**: Full PHP 8.4 type system usage with readonly classes
+- **Rich Domain Model**: Aggregate root with business rules enforcement
+
+## Installation
+
+```bash
+composer require software-archetypes/simple-availability
+```
+
+## Core Concepts
+
+### Asset Availability States
+
+1. **Maintenance Lock** - Initial state when asset is registered
+2. **Available** - Asset activated and ready for use
+3. **Owner Lock** - Time-bounded lock by a specific owner
+4. **Withdrawal Lock** - Asset withdrawn from availability
+
+### Domain Model
+
+#### Value Objects
+- `AssetId` - Unique identifier for assets
+- `OwnerId` - Unique identifier for owners
+
+#### Aggregate Root
+- `AssetAvailability` - Main aggregate managing availability rules
+
+#### Lock Types
+- `MaintenanceLock` - Initial maintenance state
+- `WithdrawalLock` - Withdrawn state
+- `OwnerLock` - Time-bounded owner lock
+
+### Commands
+
+- `Register` - Register a new asset
+- `Activate` - Activate asset (remove maintenance lock)
+- `Withdraw` - Withdraw asset from availability
+- `Lock` - Lock asset for specified duration
+- `LockIndefinitely` - Extend existing lock to 365 days
+- `Unlock` - Release asset lock
+
+### Domain Events
+
+Success events:
+- `AssetRegistered`
+- `AssetActivated`
+- `AssetLocked`
+- `AssetUnlocked`
+- `AssetWithdrawn`
+- `AssetLockExpired`
+
+Rejection events:
+- `AssetRegistrationRejected`
+- `AssetActivationRejected`
+- `AssetLockRejected`
+- `AssetUnlockingRejected`
+- `AssetWithdrawalRejected`
+
+## Usage Examples
+
+### Basic Workflow
+
+```php
+use SoftwareArchetypes\Availability\SimpleAvailability\Application\AvailabilityService;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\Repository\InMemoryAssetAvailabilityRepository;
+use SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\EventPublisher\InMemoryDomainEventsPublisher;
+
+// Setup
+$repository = new InMemoryAssetAvailabilityRepository();
+$eventsPublisher = new InMemoryDomainEventsPublisher();
+$service = new AvailabilityService($repository, $eventsPublisher);
+
+// Register new asset
+$assetId = AssetId::of('asset-123');
+$result = $service->registerAssetWith($assetId);
+
+if ($result->isSuccess()) {
+    echo "Asset registered successfully\n";
+}
+
+// Activate asset
+$result = $service->activate($assetId);
+
+// Lock asset
+$ownerId = OwnerId::of('owner-456');
+$duration = new DateInterval('PT1H'); // 1 hour
+$result = $service->lock($assetId, $ownerId, $duration);
+
+if ($result->isSuccess()) {
+    echo "Asset locked successfully\n";
+}
+
+// Unlock asset
+$result = $service->unlock($assetId, $ownerId, new DateTimeImmutable());
+```
+
+### Working with Domain Model Directly
+
+```php
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+
+$asset = AssetAvailability::of(AssetId::of('asset-123'));
+
+// Activate
+$result = $asset->activate();
+$result->fold(
+    fn($event) => echo "Activated: " . $event->getType(),
+    fn($event) => echo "Rejected: " . $event->getReason()
+);
+
+// Lock for 30 minutes
+$ownerId = OwnerId::of('owner-456');
+$result = $asset->lockFor($ownerId, new DateInterval('PT30M'));
+
+// Check result
+if ($result->isSuccess()) {
+    $event = $result->getSuccess();
+    echo "Locked until: " . $event->getTo()->format('Y-m-d H:i:s');
+}
+```
+
+### Result Monad Usage
+
+```php
+$result = $service->activate($assetId);
+
+// Map success value
+$mapped = $result->map(fn($event) => $event->getType());
+
+// Fold to single value
+$message = $result->fold(
+    fn($success) => "Success: {$success->getType()}",
+    fn($failure) => "Error: {$failure->getReason()}"
+);
+
+// Side effects
+$result->peekSuccess(fn($event) => $logger->info("Asset activated"))
+       ->peekFailure(fn($event) => $logger->error("Activation failed"));
+```
+
+## Business Rules
+
+1. **Registration**: Asset must not exist
+2. **Activation**: Only assets with MaintenanceLock can be activated
+3. **Locking**: Only available (not locked) assets can be locked
+4. **Lock Extension**: Only owner with existing lock can extend indefinitely
+5. **Unlocking**: Only the lock owner can unlock
+6. **Withdrawal**: Only available or maintenance assets can be withdrawn
+
+## Architecture
+
+```
+src/
+├── Application/          # Application services
+│   ├── AvailabilityService.php
+│   └── OverdueLockHandling.php
+├── Commands/            # Command objects
+├── Common/              # Shared utilities (Result monad)
+├── Domain/              # Domain model
+│   ├── AssetAvailability.php (Aggregate Root)
+│   ├── AssetId.php
+│   ├── OwnerId.php
+│   └── Lock types
+├── Events/              # Domain events
+└── Infrastructure/      # Infrastructure implementations
+    ├── Repository/
+    └── EventPublisher/
+```
+
+## Testing
+
+```bash
+# Run tests
+composer test
+
+# Run with coverage
+composer test-coverage
+
+# Run PHPStan
+composer phpstan
+
+# Check code style
+composer cs-check
+
+# Fix code style
+composer cs-fix
+```
+
+## PHP 8.4 Features Used
+
+- **Readonly classes**: Immutable value objects and events
+- **Property hooks**: (when available)
+- **Constructor property promotion**: Concise class definitions
+- **Named arguments**: Clear method calls
+- **Enums**: Type-safe constants
+- **Generics via PHPDoc**: Type-safe Result monad
+
+## Differences from Java Implementation
+
+1. **DateInterval vs Duration**: PHP uses `DateInterval` instead of Java's `Duration`
+2. **Nullable types**: PHP uses `?Type` instead of Java's `Optional<T>`
+3. **Array storage**: In-memory repository uses PHP arrays
+4. **No sealed classes**: PHP doesn't have sealed classes (yet), using interfaces instead
+5. **Closure syntax**: PHP closures use `fn()` and `function()` instead of Java lambdas
+
+## Contributing
+
+Contributions are welcome! Please ensure:
+- All tests pass
+- Code follows PSR-12 standards
+- PHPStan level max passes
+- New features include tests and documentation
+
+## License
+
+MIT License - See LICENSE file for details
+
+## Credits
+
+This is a PHP port of the original Java implementation from the [Software Archetypes](https://github.com/Software-Archetypes/archetypes) project.
+
+## Related Patterns
+
+- **Timed Availability**: Time-slot based availability
+- **Capacity**: Quantity-based resource management
+- **Reservation**: Booking and reservation systems

--- a/availability/simple-availability/composer.json
+++ b/availability/simple-availability/composer.json
@@ -1,0 +1,51 @@
+{
+    "name": "software-archetypes/simple-availability",
+    "description": "Simple Availability pattern implementation in PHP - Port from Software Archetypes Java project",
+    "type": "library",
+    "license": "MIT",
+    "keywords": [
+        "ddd",
+        "domain-driven-design",
+        "availability",
+        "software-archetypes",
+        "aggregate",
+        "event-sourcing"
+    ],
+    "authors": [
+        {
+            "name": "Software Archetypes PHP",
+            "email": "info@example.com"
+        }
+    ],
+    "require": {
+        "php": "^8.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0",
+        "phpstan/phpstan": "^2.0",
+        "friendsofphp/php-cs-fixer": "^3.64"
+    },
+    "autoload": {
+        "psr-4": {
+            "SoftwareArchetypes\\Availability\\SimpleAvailability\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SoftwareArchetypes\\Availability\\SimpleAvailability\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true
+    },
+    "scripts": {
+        "test": "phpunit",
+        "test-coverage": "phpunit --coverage-html coverage",
+        "phpstan": "phpstan analyse src tests --level=max",
+        "cs-fix": "php-cs-fixer fix",
+        "cs-check": "php-cs-fixer fix --dry-run --diff"
+    }
+}

--- a/availability/simple-availability/composer.json
+++ b/availability/simple-availability/composer.json
@@ -21,9 +21,10 @@
         "php": "^8.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0",
+        "deptrac/deptrac": "^3.0",
+        "friendsofphp/php-cs-fixer": "^3.64",
         "phpstan/phpstan": "^2.0",
-        "friendsofphp/php-cs-fixer": "^3.64"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/availability/simple-availability/deptrac.yaml
+++ b/availability/simple-availability/deptrac.yaml
@@ -1,0 +1,59 @@
+deptrac:
+  paths:
+    - ./src
+  exclude_files:
+    - '#.*test.*#i'
+  layers:
+    - name: Common
+      collectors:
+        - type: directory
+          value: src/Common/.*
+    - name: Domain
+      collectors:
+        - type: directory
+          value: src/Domain/.*
+    - name: Events
+      collectors:
+        - type: directory
+          value: src/Events/.*
+    - name: Commands
+      collectors:
+        - type: directory
+          value: src/Commands/.*
+    - name: Application
+      collectors:
+        - type: directory
+          value: src/Application/.*
+    - name: Infrastructure
+      collectors:
+        - type: directory
+          value: src/Infrastructure/.*
+  ruleset:
+    Common: []
+    Domain:
+      - Common
+      - Events
+    Events:
+      - Domain
+      - Common
+    Commands:
+      - Domain
+      - Common
+    Application:
+      - Domain
+      - Events
+      - Commands
+      - Common
+      - Infrastructure
+    Infrastructure:
+      - Domain
+      - Events
+      - Common
+  skip_violations: []
+  analyser:
+    types:
+      - class
+      - class_superglobal
+      - file
+      - function
+      - function_superglobal

--- a/availability/simple-availability/phpstan.neon
+++ b/availability/simple-availability/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: max
+    paths:
+        - src
+        - tests
+    phpVersion: 80400

--- a/availability/simple-availability/phpunit.xml
+++ b/availability/simple-availability/phpunit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnRisky="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true">
+    <testsuites>
+        <testsuite name="Simple Availability Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+
+    <coverage>
+        <report>
+            <html outputDirectory="coverage"/>
+        </report>
+    </coverage>
+</phpunit>

--- a/availability/simple-availability/src/Application/AvailabilityService.php
+++ b/availability/simple-availability/src/Application/AvailabilityService.php
@@ -12,8 +12,17 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailabilityRepository;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivated;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivationRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLockRejected;
 use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetRegistered;
 use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetRegistrationRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetUnlocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetUnlockingRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawalRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawn;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\DomainEvent;
 use SoftwareArchetypes\Availability\SimpleAvailability\Events\DomainEventsPublisher;
 
 class AvailabilityService
@@ -45,6 +54,9 @@ class AvailabilityService
         return Result::success($event);
     }
 
+    /**
+     * @return Result<string|AssetActivationRejected, AssetActivated>
+     */
     public function activate(AssetId $assetId): Result
     {
         $assetAvailability = $this->repository->findById($assetId);
@@ -58,6 +70,9 @@ class AvailabilityService
         return $result;
     }
 
+    /**
+     * @return Result<string|AssetWithdrawalRejected, AssetWithdrawn>
+     */
     public function withdraw(AssetId $assetId): Result
     {
         $assetAvailability = $this->repository->findById($assetId);
@@ -71,6 +86,9 @@ class AvailabilityService
         return $result;
     }
 
+    /**
+     * @return Result<string|AssetLockRejected, AssetLocked>
+     */
     public function lock(AssetId $assetId, OwnerId $ownerId, DateInterval $duration): Result
     {
         $assetAvailability = $this->repository->findById($assetId);
@@ -84,6 +102,9 @@ class AvailabilityService
         return $result;
     }
 
+    /**
+     * @return Result<string|AssetLockRejected, AssetLocked>
+     */
     public function lockIndefinitely(AssetId $assetId, OwnerId $ownerId): Result
     {
         $assetAvailability = $this->repository->findById($assetId);
@@ -97,6 +118,9 @@ class AvailabilityService
         return $result;
     }
 
+    /**
+     * @return Result<string|AssetUnlockingRejected, AssetUnlocked>
+     */
     public function unlock(AssetId $assetId, OwnerId $ownerId, DateTimeImmutable $at): Result
     {
         $assetAvailability = $this->repository->findById($assetId);
@@ -124,12 +148,15 @@ class AvailabilityService
         }
     }
 
+    /**
+     * @param Result<DomainEvent, DomainEvent> $result
+     */
     private function handle(AssetAvailability $assetAvailability, Result $result): void
     {
         $this->repository->save($assetAvailability);
         $result->peekBoth(
-            fn($event) => $this->eventsPublisher->publish($event),
-            fn($event) => $this->eventsPublisher->publish($event)
+            fn(DomainEvent $event) => $this->eventsPublisher->publish($event),
+            fn(DomainEvent $event) => $this->eventsPublisher->publish($event)
         );
     }
 }

--- a/availability/simple-availability/src/Application/AvailabilityService.php
+++ b/availability/simple-availability/src/Application/AvailabilityService.php
@@ -6,6 +6,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Application;
 
 use DateInterval;
 use DateTimeImmutable;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Clock;
 use SoftwareArchetypes\Availability\SimpleAvailability\Common\Result;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailabilityRepository;
@@ -19,7 +20,8 @@ class AvailabilityService
 {
     public function __construct(
         private readonly AssetAvailabilityRepository $repository,
-        private readonly DomainEventsPublisher $eventsPublisher
+        private readonly DomainEventsPublisher $eventsPublisher,
+        private readonly Clock $clock
     ) {
     }
 
@@ -34,7 +36,7 @@ class AvailabilityService
             return Result::failure($event);
         }
 
-        $assetAvailability = AssetAvailability::of($assetId);
+        $assetAvailability = AssetAvailability::of($assetId, $this->clock);
         $this->repository->save($assetAvailability);
 
         $event = AssetRegistered::from($assetId);

--- a/availability/simple-availability/src/Application/AvailabilityService.php
+++ b/availability/simple-availability/src/Application/AvailabilityService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Application;
+
+use DateInterval;
+use DateTimeImmutable;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Result;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailabilityRepository;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetRegistered;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetRegistrationRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\DomainEventsPublisher;
+
+class AvailabilityService
+{
+    public function __construct(
+        private readonly AssetAvailabilityRepository $repository,
+        private readonly DomainEventsPublisher $eventsPublisher
+    ) {
+    }
+
+    /**
+     * @return Result<AssetRegistrationRejected, AssetRegistered>
+     */
+    public function registerAssetWith(AssetId $assetId): Result
+    {
+        if ($this->repository->existsById($assetId)) {
+            $event = AssetRegistrationRejected::from($assetId, 'ASSET_ALREADY_EXISTS');
+            $this->eventsPublisher->publish($event);
+            return Result::failure($event);
+        }
+
+        $assetAvailability = AssetAvailability::of($assetId);
+        $this->repository->save($assetAvailability);
+
+        $event = AssetRegistered::from($assetId);
+        $this->eventsPublisher->publish($event);
+
+        return Result::success($event);
+    }
+
+    public function activate(AssetId $assetId): Result
+    {
+        $assetAvailability = $this->repository->findById($assetId);
+        if ($assetAvailability === null) {
+            return Result::failure('Asset not found');
+        }
+
+        $result = $assetAvailability->activate();
+        $this->handle($assetAvailability, $result);
+
+        return $result;
+    }
+
+    public function withdraw(AssetId $assetId): Result
+    {
+        $assetAvailability = $this->repository->findById($assetId);
+        if ($assetAvailability === null) {
+            return Result::failure('Asset not found');
+        }
+
+        $result = $assetAvailability->withdraw();
+        $this->handle($assetAvailability, $result);
+
+        return $result;
+    }
+
+    public function lock(AssetId $assetId, OwnerId $ownerId, DateInterval $duration): Result
+    {
+        $assetAvailability = $this->repository->findById($assetId);
+        if ($assetAvailability === null) {
+            return Result::failure('Asset not found');
+        }
+
+        $result = $assetAvailability->lockFor($ownerId, $duration);
+        $this->handle($assetAvailability, $result);
+
+        return $result;
+    }
+
+    public function lockIndefinitely(AssetId $assetId, OwnerId $ownerId): Result
+    {
+        $assetAvailability = $this->repository->findById($assetId);
+        if ($assetAvailability === null) {
+            return Result::failure('Asset not found');
+        }
+
+        $result = $assetAvailability->lockIndefinitelyFor($ownerId);
+        $this->handle($assetAvailability, $result);
+
+        return $result;
+    }
+
+    public function unlock(AssetId $assetId, OwnerId $ownerId, DateTimeImmutable $at): Result
+    {
+        $assetAvailability = $this->repository->findById($assetId);
+        if ($assetAvailability === null) {
+            return Result::failure('Asset not found');
+        }
+
+        $result = $assetAvailability->unlockFor($ownerId, $at);
+        $this->handle($assetAvailability, $result);
+
+        return $result;
+    }
+
+    public function unlockIfOverdue(AssetId $assetId): void
+    {
+        $assetAvailability = $this->repository->findById($assetId);
+        if ($assetAvailability === null) {
+            return;
+        }
+
+        $event = $assetAvailability->unlockIfOverdue();
+        if ($event !== null) {
+            $this->repository->save($assetAvailability);
+            $this->eventsPublisher->publish($event);
+        }
+    }
+
+    private function handle(AssetAvailability $assetAvailability, Result $result): void
+    {
+        $this->repository->save($assetAvailability);
+        $result->peekBoth(
+            fn($event) => $this->eventsPublisher->publish($event),
+            fn($event) => $this->eventsPublisher->publish($event)
+        );
+    }
+}

--- a/availability/simple-availability/src/Application/OverdueLockHandling.php
+++ b/availability/simple-availability/src/Application/OverdueLockHandling.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Application;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+
+interface OverdueLockHandling
+{
+    public function processOverdueLocks(): void;
+
+    public function processOverdueLock(AssetId $assetId): void;
+}

--- a/availability/simple-availability/src/Commands/Activate.php
+++ b/availability/simple-availability/src/Commands/Activate.php
@@ -6,7 +6,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
 
 final readonly class Activate implements Command
 {
-    public const TYPE = 'ACTIVATE';
+    public const string TYPE = 'ACTIVATE';
 
     public function __construct(
         public string $assetId

--- a/availability/simple-availability/src/Commands/Activate.php
+++ b/availability/simple-availability/src/Commands/Activate.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
+
+final readonly class Activate implements Command
+{
+    public const TYPE = 'ACTIVATE';
+
+    public function __construct(
+        public string $assetId
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Commands/Command.php
+++ b/availability/simple-availability/src/Commands/Command.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
+
+interface Command
+{
+    public function getType(): string;
+}

--- a/availability/simple-availability/src/Commands/Lock.php
+++ b/availability/simple-availability/src/Commands/Lock.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
+
+final readonly class Lock implements Command
+{
+    public const TYPE = 'LOCK';
+
+    public function __construct(
+        public string $assetId,
+        public int $durationInMinutes
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Commands/Lock.php
+++ b/availability/simple-availability/src/Commands/Lock.php
@@ -6,7 +6,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
 
 final readonly class Lock implements Command
 {
-    public const TYPE = 'LOCK';
+    public const string TYPE = 'LOCK';
 
     public function __construct(
         public string $assetId,

--- a/availability/simple-availability/src/Commands/LockIndefinitely.php
+++ b/availability/simple-availability/src/Commands/LockIndefinitely.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
+
+final readonly class LockIndefinitely implements Command
+{
+    public const TYPE = 'LOCK_INDEFINITELY';
+
+    public function __construct(
+        public string $assetId
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Commands/LockIndefinitely.php
+++ b/availability/simple-availability/src/Commands/LockIndefinitely.php
@@ -6,7 +6,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
 
 final readonly class LockIndefinitely implements Command
 {
-    public const TYPE = 'LOCK_INDEFINITELY';
+    public const string TYPE = 'LOCK_INDEFINITELY';
 
     public function __construct(
         public string $assetId

--- a/availability/simple-availability/src/Commands/Register.php
+++ b/availability/simple-availability/src/Commands/Register.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
+
+final readonly class Register implements Command
+{
+    public const TYPE = 'REGISTER';
+
+    public function __construct(
+        public string $assetId
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Commands/Register.php
+++ b/availability/simple-availability/src/Commands/Register.php
@@ -6,7 +6,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
 
 final readonly class Register implements Command
 {
-    public const TYPE = 'REGISTER';
+    public const string TYPE = 'REGISTER';
 
     public function __construct(
         public string $assetId

--- a/availability/simple-availability/src/Commands/Unlock.php
+++ b/availability/simple-availability/src/Commands/Unlock.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
+
+final readonly class Unlock implements Command
+{
+    public const TYPE = 'UNLOCK';
+
+    public function __construct(
+        public string $assetId
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Commands/Unlock.php
+++ b/availability/simple-availability/src/Commands/Unlock.php
@@ -6,7 +6,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
 
 final readonly class Unlock implements Command
 {
-    public const TYPE = 'UNLOCK';
+    public const string TYPE = 'UNLOCK';
 
     public function __construct(
         public string $assetId

--- a/availability/simple-availability/src/Commands/Withdraw.php
+++ b/availability/simple-availability/src/Commands/Withdraw.php
@@ -6,7 +6,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
 
 final readonly class Withdraw implements Command
 {
-    public const TYPE = 'WITHDRAW';
+    public const string TYPE = 'WITHDRAW';
 
     public function __construct(
         public string $assetId

--- a/availability/simple-availability/src/Commands/Withdraw.php
+++ b/availability/simple-availability/src/Commands/Withdraw.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Commands;
+
+final readonly class Withdraw implements Command
+{
+    public const TYPE = 'WITHDRAW';
+
+    public function __construct(
+        public string $assetId
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Common/Clock.php
+++ b/availability/simple-availability/src/Common/Clock.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Common;
+
+use DateTimeImmutable;
+
+interface Clock
+{
+    public function now(): DateTimeImmutable;
+}

--- a/availability/simple-availability/src/Common/Result.php
+++ b/availability/simple-availability/src/Common/Result.php
@@ -7,8 +7,8 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Common;
 use Closure;
 
 /**
- * @template F
- * @template S
+ * @template-covariant F
+ * @template-covariant S
  */
 final readonly class Result
 {
@@ -26,20 +26,24 @@ final readonly class Result
     /**
      * @template T
      * @param T $value
-     * @return self<never, T>
+     * @return self<null, T>
+     * @phpstan-return self<never, T>
      */
     public static function success(mixed $value): self
     {
+        /** @phpstan-ignore-next-line */
         return new self($value, null, true);
     }
 
     /**
      * @template T
      * @param T $value
-     * @return self<T, never>
+     * @return self<T, null>
+     * @phpstan-return self<T, never>
      */
     public static function failure(mixed $value): self
     {
+        /** @phpstan-ignore-next-line */
         return new self(null, $value, false);
     }
 
@@ -61,6 +65,7 @@ final readonly class Result
         if (!$this->isSuccess) {
             throw new \LogicException('Cannot get success value from a failure result');
         }
+        assert($this->success !== null);
         return $this->success;
     }
 
@@ -72,6 +77,7 @@ final readonly class Result
         if ($this->isSuccess) {
             throw new \LogicException('Cannot get failure value from a success result');
         }
+        assert($this->failure !== null);
         return $this->failure;
     }
 
@@ -83,8 +89,10 @@ final readonly class Result
     public function map(Closure $mapper): self
     {
         if ($this->isSuccess) {
+            assert($this->success !== null);
             return self::success($mapper($this->success));
         }
+        /** @var self<F, T> */
         return self::failure($this->failure);
     }
 
@@ -96,8 +104,10 @@ final readonly class Result
     public function mapFailure(Closure $mapper): self
     {
         if ($this->isFailure()) {
+            assert($this->failure !== null);
             return self::failure($mapper($this->failure));
         }
+        /** @var self<T, S> */
         return self::success($this->success);
     }
 
@@ -110,8 +120,10 @@ final readonly class Result
     public function flatMap(Closure $mapper): self
     {
         if ($this->isSuccess) {
+            /** @phpstan-ignore-next-line */
             return $mapper($this->success);
         }
+        /** @var self<F|SF, SS> */
         return self::failure($this->failure);
     }
 
@@ -123,9 +135,12 @@ final readonly class Result
      */
     public function fold(Closure $successMapper, Closure $failureMapper): mixed
     {
-        return $this->isSuccess
-            ? $successMapper($this->success)
-            : $failureMapper($this->failure);
+        if ($this->isSuccess) {
+            assert($this->success !== null);
+            return $successMapper($this->success);
+        }
+        assert($this->failure !== null);
+        return $failureMapper($this->failure);
     }
 
     /**
@@ -135,6 +150,7 @@ final readonly class Result
     public function peek(Closure $action): self
     {
         if ($this->isSuccess) {
+            assert($this->success !== null);
             $action($this->success);
         }
         return $this;
@@ -156,6 +172,7 @@ final readonly class Result
     public function peekFailure(Closure $action): self
     {
         if ($this->isFailure()) {
+            assert($this->failure !== null);
             $action($this->failure);
         }
         return $this;
@@ -169,8 +186,10 @@ final readonly class Result
     public function peekBoth(Closure $successAction, Closure $failureAction): self
     {
         if ($this->isSuccess) {
+            assert($this->success !== null);
             $successAction($this->success);
         } else {
+            assert($this->failure !== null);
             $failureAction($this->failure);
         }
         return $this;
@@ -182,11 +201,15 @@ final readonly class Result
      * @param Closure(F): self<F, T> $failureMapper
      * @return self<F, T>
      */
+    /** @phpstan-ignore-next-line generics.variance */
     public function ifSuccessOrElse(Closure $successMapper, Closure $failureMapper): self
     {
         if ($this->isSuccess) {
+            assert($this->success !== null);
             return self::success($successMapper($this->success));
         }
+        assert($this->failure !== null);
+        /** @phpstan-ignore-next-line */
         return $failureMapper($this->failure);
     }
 
@@ -199,8 +222,11 @@ final readonly class Result
      */
     public function biMap(Closure $successMapper, Closure $failureMapper): self
     {
-        return $this->isSuccess
-            ? self::success($successMapper($this->success))
-            : self::failure($failureMapper($this->failure));
+        if ($this->isSuccess) {
+            assert($this->success !== null);
+            return self::success($successMapper($this->success));
+        }
+        assert($this->failure !== null);
+        return self::failure($failureMapper($this->failure));
     }
 }

--- a/availability/simple-availability/src/Common/Result.php
+++ b/availability/simple-availability/src/Common/Result.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Common;
+
+use Closure;
+
+/**
+ * @template F
+ * @template S
+ */
+final readonly class Result
+{
+    /**
+     * @param S|null $success
+     * @param F|null $failure
+     */
+    private function __construct(
+        private mixed $success,
+        private mixed $failure,
+        private bool $isSuccess
+    ) {
+    }
+
+    /**
+     * @template T
+     * @param T $value
+     * @return self<never, T>
+     */
+    public static function success(mixed $value): self
+    {
+        return new self($value, null, true);
+    }
+
+    /**
+     * @template T
+     * @param T $value
+     * @return self<T, never>
+     */
+    public static function failure(mixed $value): self
+    {
+        return new self(null, $value, false);
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->isSuccess;
+    }
+
+    public function isFailure(): bool
+    {
+        return !$this->isSuccess;
+    }
+
+    /**
+     * @return S
+     */
+    public function getSuccess(): mixed
+    {
+        if (!$this->isSuccess) {
+            throw new \LogicException('Cannot get success value from a failure result');
+        }
+        return $this->success;
+    }
+
+    /**
+     * @return F
+     */
+    public function getFailure(): mixed
+    {
+        if ($this->isSuccess) {
+            throw new \LogicException('Cannot get failure value from a success result');
+        }
+        return $this->failure;
+    }
+
+    /**
+     * @template T
+     * @param Closure(S): T $mapper
+     * @return self<F, T>
+     */
+    public function map(Closure $mapper): self
+    {
+        if ($this->isSuccess) {
+            return self::success($mapper($this->success));
+        }
+        return self::failure($this->failure);
+    }
+
+    /**
+     * @template T
+     * @param Closure(F): T $mapper
+     * @return self<T, S>
+     */
+    public function mapFailure(Closure $mapper): self
+    {
+        if ($this->isFailure()) {
+            return self::failure($mapper($this->failure));
+        }
+        return self::success($this->success);
+    }
+
+    /**
+     * @template SF
+     * @template SS
+     * @param Closure(S): self<SF, SS> $mapper
+     * @return self<F|SF, SS>
+     */
+    public function flatMap(Closure $mapper): self
+    {
+        if ($this->isSuccess) {
+            return $mapper($this->success);
+        }
+        return self::failure($this->failure);
+    }
+
+    /**
+     * @template T
+     * @param Closure(S): T $successMapper
+     * @param Closure(F): T $failureMapper
+     * @return T
+     */
+    public function fold(Closure $successMapper, Closure $failureMapper): mixed
+    {
+        return $this->isSuccess
+            ? $successMapper($this->success)
+            : $failureMapper($this->failure);
+    }
+
+    /**
+     * @param Closure(S): void $action
+     * @return self<F, S>
+     */
+    public function peek(Closure $action): self
+    {
+        if ($this->isSuccess) {
+            $action($this->success);
+        }
+        return $this;
+    }
+
+    /**
+     * @param Closure(S): void $action
+     * @return self<F, S>
+     */
+    public function peekSuccess(Closure $action): self
+    {
+        return $this->peek($action);
+    }
+
+    /**
+     * @param Closure(F): void $action
+     * @return self<F, S>
+     */
+    public function peekFailure(Closure $action): self
+    {
+        if ($this->isFailure()) {
+            $action($this->failure);
+        }
+        return $this;
+    }
+
+    /**
+     * @param Closure(S): void $successAction
+     * @param Closure(F): void $failureAction
+     * @return self<F, S>
+     */
+    public function peekBoth(Closure $successAction, Closure $failureAction): self
+    {
+        if ($this->isSuccess) {
+            $successAction($this->success);
+        } else {
+            $failureAction($this->failure);
+        }
+        return $this;
+    }
+
+    /**
+     * @template T
+     * @param Closure(S): T $successMapper
+     * @param Closure(F): self<F, T> $failureMapper
+     * @return self<F, T>
+     */
+    public function ifSuccessOrElse(Closure $successMapper, Closure $failureMapper): self
+    {
+        if ($this->isSuccess) {
+            return self::success($successMapper($this->success));
+        }
+        return $failureMapper($this->failure);
+    }
+
+    /**
+     * @template FS
+     * @template FF
+     * @param Closure(S): FS $successMapper
+     * @param Closure(F): FF $failureMapper
+     * @return self<FF, FS>
+     */
+    public function biMap(Closure $successMapper, Closure $failureMapper): self
+    {
+        return $this->isSuccess
+            ? self::success($successMapper($this->success))
+            : self::failure($failureMapper($this->failure));
+    }
+}

--- a/availability/simple-availability/src/Common/SystemClock.php
+++ b/availability/simple-availability/src/Common/SystemClock.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Common;
+
+use DateTimeImmutable;
+
+final class SystemClock implements Clock
+{
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/availability/simple-availability/src/Domain/AssetAvailability.php
+++ b/availability/simple-availability/src/Domain/AssetAvailability.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
+
+use DateInterval;
+use DateTimeImmutable;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Result;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivated;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivationRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLockExpired;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLockRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetUnlocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetUnlockingRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawalRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawn;
+
+class AssetAvailability
+{
+    private const ASSET_LOCKED_REASON = 'ASSET_CURRENTLY_LOCKED';
+    private const NO_LOCK_ON_THE_ASSET_REASON = 'NO_LOCK_ON_THE_ASSET';
+    private const NO_LOCK_DEFINED_FOR_OWNER_REASON = 'NO_LOCK_DEFINED_FOR_OWNER';
+    private const ASSET_ALREADY_ACTIVATED_REASON = 'ASSET_ALREADY_ACTIVATED';
+    private const INDEFINITE_LOCK_DAYS = 365;
+
+    private ?Lock $currentLock;
+
+    private function __construct(
+        private readonly AssetId $assetId
+    ) {
+        $this->currentLock = new MaintenanceLock();
+    }
+
+    public static function of(AssetId $assetId): self
+    {
+        return new self($assetId);
+    }
+
+    /**
+     * @return Result<AssetActivationRejected, AssetActivated>
+     */
+    public function activate(): Result
+    {
+        if ($this->currentLock instanceof MaintenanceLock) {
+            $this->currentLock = null;
+            return Result::success(AssetActivated::from($this->assetId));
+        }
+        return Result::failure(
+            AssetActivationRejected::from($this->assetId, self::ASSET_ALREADY_ACTIVATED_REASON)
+        );
+    }
+
+    /**
+     * @return Result<AssetWithdrawalRejected, AssetWithdrawn>
+     */
+    public function withdraw(): Result
+    {
+        if ($this->currentLock === null || $this->currentLock instanceof MaintenanceLock) {
+            $this->currentLock = new WithdrawalLock();
+            return Result::success(AssetWithdrawn::from($this->assetId));
+        }
+        return Result::failure(
+            AssetWithdrawalRejected::from($this->assetId, self::ASSET_LOCKED_REASON)
+        );
+    }
+
+    /**
+     * @return Result<AssetLockRejected, AssetLocked>
+     */
+    public function lockFor(OwnerId $ownerId, DateInterval $time): Result
+    {
+        if ($this->currentLock === null) {
+            $now = new DateTimeImmutable();
+            $validUntil = $now->add($time);
+            $this->currentLock = new OwnerLock($ownerId, $validUntil);
+            return Result::success(
+                AssetLocked::from($this->assetId, $ownerId, $now, $validUntil)
+            );
+        }
+        return Result::failure(
+            AssetLockRejected::from($this->assetId, $ownerId, self::ASSET_LOCKED_REASON)
+        );
+    }
+
+    /**
+     * @return Result<AssetLockRejected, AssetLocked>
+     */
+    public function lockIndefinitelyFor(OwnerId $ownerId): Result
+    {
+        if ($this->thereIsAnActiveLockFor($ownerId)) {
+            $now = new DateTimeImmutable();
+            $validUntil = $now->add(new DateInterval('P' . self::INDEFINITE_LOCK_DAYS . 'D'));
+            $this->currentLock = new OwnerLock($ownerId, $validUntil);
+            return Result::success(
+                AssetLocked::from($this->assetId, $ownerId, $now, $validUntil)
+            );
+        }
+        return Result::failure(
+            AssetLockRejected::from($this->assetId, $ownerId, self::NO_LOCK_DEFINED_FOR_OWNER_REASON)
+        );
+    }
+
+    /**
+     * @return Result<AssetUnlockingRejected, AssetUnlocked>
+     */
+    public function unlockFor(OwnerId $ownerId, DateTimeImmutable $at): Result
+    {
+        if ($this->thereIsAnActiveLockFor($ownerId)) {
+            $this->currentLock = null;
+            return Result::success(AssetUnlocked::from($this->assetId, $ownerId));
+        }
+        return Result::failure(
+            AssetUnlockingRejected::from($this->assetId, $ownerId, self::NO_LOCK_ON_THE_ASSET_REASON)
+        );
+    }
+
+    public function unlockIfOverdue(): ?AssetLockExpired
+    {
+        if ($this->currentLock instanceof OwnerLock) {
+            $ownerId = $this->currentLock->ownerId();
+            $this->currentLock = null;
+            return AssetLockExpired::from($this->assetId, $ownerId);
+        }
+        return null;
+    }
+
+    public function id(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function currentLock(): ?Lock
+    {
+        return $this->currentLock;
+    }
+
+    private function thereIsAnActiveLockFor(OwnerId $ownerId): bool
+    {
+        return $this->currentLock !== null && $this->currentLock->wasMadeFor($ownerId);
+    }
+
+    public function with(Lock $lock): self
+    {
+        $this->currentLock = $lock;
+        return $this;
+    }
+}

--- a/availability/simple-availability/src/Domain/AssetAvailability.php
+++ b/availability/simple-availability/src/Domain/AssetAvailability.php
@@ -19,11 +19,11 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawn;
 
 class AssetAvailability
 {
-    private const ASSET_LOCKED_REASON = 'ASSET_CURRENTLY_LOCKED';
-    private const NO_LOCK_ON_THE_ASSET_REASON = 'NO_LOCK_ON_THE_ASSET';
-    private const NO_LOCK_DEFINED_FOR_OWNER_REASON = 'NO_LOCK_DEFINED_FOR_OWNER';
-    private const ASSET_ALREADY_ACTIVATED_REASON = 'ASSET_ALREADY_ACTIVATED';
-    private const INDEFINITE_LOCK_DAYS = 365;
+    private const string ASSET_LOCKED_REASON = 'ASSET_CURRENTLY_LOCKED';
+    private const string NO_LOCK_ON_THE_ASSET_REASON = 'NO_LOCK_ON_THE_ASSET';
+    private const string NO_LOCK_DEFINED_FOR_OWNER_REASON = 'NO_LOCK_DEFINED_FOR_OWNER';
+    private const string ASSET_ALREADY_ACTIVATED_REASON = 'ASSET_ALREADY_ACTIVATED';
+    private const int INDEFINITE_LOCK_DAYS = 365;
 
     private ?Lock $currentLock;
 

--- a/availability/simple-availability/src/Domain/AssetAvailability.php
+++ b/availability/simple-availability/src/Domain/AssetAvailability.php
@@ -6,6 +6,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
 
 use DateInterval;
 use DateTimeImmutable;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Clock;
 use SoftwareArchetypes\Availability\SimpleAvailability\Common\Result;
 use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivated;
 use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivationRejected;
@@ -28,14 +29,15 @@ class AssetAvailability
     private ?Lock $currentLock;
 
     private function __construct(
-        private readonly AssetId $assetId
+        private readonly AssetId $assetId,
+        private readonly Clock $clock
     ) {
         $this->currentLock = new MaintenanceLock();
     }
 
-    public static function of(AssetId $assetId): self
+    public static function of(AssetId $assetId, Clock $clock): self
     {
-        return new self($assetId);
+        return new self($assetId, $clock);
     }
 
     /**
@@ -72,7 +74,7 @@ class AssetAvailability
     public function lockFor(OwnerId $ownerId, DateInterval $time): Result
     {
         if ($this->currentLock === null) {
-            $now = new DateTimeImmutable();
+            $now = $this->clock->now();
             $validUntil = $now->add($time);
             $this->currentLock = new OwnerLock($ownerId, $validUntil);
             return Result::success(
@@ -90,7 +92,7 @@ class AssetAvailability
     public function lockIndefinitelyFor(OwnerId $ownerId): Result
     {
         if ($this->thereIsAnActiveLockFor($ownerId)) {
-            $now = new DateTimeImmutable();
+            $now = $this->clock->now();
             $validUntil = $now->add(new DateInterval('P' . self::INDEFINITE_LOCK_DAYS . 'D'));
             $this->currentLock = new OwnerLock($ownerId, $validUntil);
             return Result::success(

--- a/availability/simple-availability/src/Domain/AssetAvailabilityRepository.php
+++ b/availability/simple-availability/src/Domain/AssetAvailabilityRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
+
+interface AssetAvailabilityRepository
+{
+    public function save(AssetAvailability $assetAvailability): void;
+
+    public function findById(AssetId $assetId): ?AssetAvailability;
+
+    public function existsById(AssetId $assetId): bool;
+}

--- a/availability/simple-availability/src/Domain/AssetId.php
+++ b/availability/simple-availability/src/Domain/AssetId.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
+
+use JsonSerializable;
+use Stringable;
+
+final readonly class AssetId implements JsonSerializable, Stringable
+{
+    private function __construct(
+        private string $value
+    ) {
+    }
+
+    public static function of(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(?self $other): bool
+    {
+        return $other !== null && $this->value === $other->value;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/availability/simple-availability/src/Domain/Lock.php
+++ b/availability/simple-availability/src/Domain/Lock.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
+
+interface Lock
+{
+    public function ownerId(): OwnerId;
+
+    public function wasMadeFor(OwnerId $ownerId): bool;
+}

--- a/availability/simple-availability/src/Domain/MaintenanceLock.php
+++ b/availability/simple-availability/src/Domain/MaintenanceLock.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
+
+final readonly class MaintenanceLock implements Lock
+{
+    private static ?OwnerId $maintenanceOwnerId = null;
+
+    public function ownerId(): OwnerId
+    {
+        if (self::$maintenanceOwnerId === null) {
+            self::$maintenanceOwnerId = OwnerId::of('MAINTENANCE');
+        }
+        return self::$maintenanceOwnerId;
+    }
+
+    public function wasMadeFor(OwnerId $ownerId): bool
+    {
+        return $this->ownerId()->equals($ownerId);
+    }
+}

--- a/availability/simple-availability/src/Domain/MaintenanceLock.php
+++ b/availability/simple-availability/src/Domain/MaintenanceLock.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
 
-final readonly class MaintenanceLock implements Lock
+final class MaintenanceLock implements Lock
 {
     private static ?OwnerId $maintenanceOwnerId = null;
 

--- a/availability/simple-availability/src/Domain/OwnerId.php
+++ b/availability/simple-availability/src/Domain/OwnerId.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
+
+use JsonSerializable;
+use Stringable;
+
+final readonly class OwnerId implements JsonSerializable, Stringable
+{
+    private function __construct(
+        private string $value
+    ) {
+    }
+
+    public static function of(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function asString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(?self $other): bool
+    {
+        return $other !== null && $this->value === $other->value;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/availability/simple-availability/src/Domain/OwnerLock.php
+++ b/availability/simple-availability/src/Domain/OwnerLock.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
+
+use DateTimeImmutable;
+
+final readonly class OwnerLock implements Lock
+{
+    public function __construct(
+        private OwnerId $owner,
+        private DateTimeImmutable $until
+    ) {
+    }
+
+    public function ownerId(): OwnerId
+    {
+        return $this->owner;
+    }
+
+    public function getUntil(): DateTimeImmutable
+    {
+        return $this->until;
+    }
+
+    public function wasMadeFor(OwnerId $ownerId): bool
+    {
+        return $this->owner->equals($ownerId);
+    }
+}

--- a/availability/simple-availability/src/Domain/WithdrawalLock.php
+++ b/availability/simple-availability/src/Domain/WithdrawalLock.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
 
-final readonly class WithdrawalLock implements Lock
+final class WithdrawalLock implements Lock
 {
     private static ?OwnerId $withdrawalOwnerId = null;
 

--- a/availability/simple-availability/src/Domain/WithdrawalLock.php
+++ b/availability/simple-availability/src/Domain/WithdrawalLock.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Domain;
+
+final readonly class WithdrawalLock implements Lock
+{
+    private static ?OwnerId $withdrawalOwnerId = null;
+
+    public function ownerId(): OwnerId
+    {
+        if (self::$withdrawalOwnerId === null) {
+            self::$withdrawalOwnerId = OwnerId::of('WITHDRAWAL');
+        }
+        return self::$withdrawalOwnerId;
+    }
+
+    public function wasMadeFor(OwnerId $ownerId): bool
+    {
+        return $this->ownerId()->equals($ownerId);
+    }
+}

--- a/availability/simple-availability/src/Events/AssetActivated.php
+++ b/availability/simple-availability/src/Events/AssetActivated.php
@@ -8,7 +8,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 
 final readonly class AssetActivated extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_ACTIVATED';
+    public const string TYPE = 'ASSET_ACTIVATED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetActivated.php
+++ b/availability/simple-availability/src/Events/AssetActivated.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+
+final readonly class AssetActivated extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_ACTIVATED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetActivationRejected.php
+++ b/availability/simple-availability/src/Events/AssetActivationRejected.php
@@ -8,7 +8,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 
 final readonly class AssetActivationRejected extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_ACTIVATION_REJECTED';
+    public const string TYPE = 'ASSET_ACTIVATION_REJECTED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetActivationRejected.php
+++ b/availability/simple-availability/src/Events/AssetActivationRejected.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+
+final readonly class AssetActivationRejected extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_ACTIVATION_REJECTED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId,
+        private string $reason
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId, string $reason): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId,
+            $reason
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetLockExpired.php
+++ b/availability/simple-availability/src/Events/AssetLockExpired.php
@@ -9,7 +9,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
 
 final readonly class AssetLockExpired extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_LOCK_EXPIRED';
+    public const string TYPE = 'ASSET_LOCK_EXPIRED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetLockExpired.php
+++ b/availability/simple-availability/src/Events/AssetLockExpired.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+
+final readonly class AssetLockExpired extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_LOCK_EXPIRED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId,
+        private OwnerId $ownerId
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId, OwnerId $ownerId): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId,
+            $ownerId
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getOwnerId(): OwnerId
+    {
+        return $this->ownerId;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetLockRejected.php
+++ b/availability/simple-availability/src/Events/AssetLockRejected.php
@@ -9,7 +9,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
 
 final readonly class AssetLockRejected extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_LOCK_REJECTED';
+    public const string TYPE = 'ASSET_LOCK_REJECTED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetLockRejected.php
+++ b/availability/simple-availability/src/Events/AssetLockRejected.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+
+final readonly class AssetLockRejected extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_LOCK_REJECTED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId,
+        private OwnerId $ownerId,
+        private string $reason
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId, OwnerId $ownerId, string $reason): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId,
+            $ownerId,
+            $reason
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getOwnerId(): OwnerId
+    {
+        return $this->ownerId;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetLocked.php
+++ b/availability/simple-availability/src/Events/AssetLocked.php
@@ -10,7 +10,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
 
 final readonly class AssetLocked extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_LOCKED';
+    public const string TYPE = 'ASSET_LOCKED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetLocked.php
+++ b/availability/simple-availability/src/Events/AssetLocked.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use DateTimeImmutable;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+
+final readonly class AssetLocked extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_LOCKED';
+
+    private function __construct(
+        string $id,
+        DateTimeImmutable $occurredAt,
+        private AssetId $assetId,
+        private OwnerId $ownerId,
+        private DateTimeImmutable $from,
+        private DateTimeImmutable $to
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(
+        AssetId $assetId,
+        OwnerId $ownerId,
+        DateTimeImmutable $from,
+        DateTimeImmutable $to
+    ): self {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId,
+            $ownerId,
+            $from,
+            $to
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getOwnerId(): OwnerId
+    {
+        return $this->ownerId;
+    }
+
+    public function getFrom(): DateTimeImmutable
+    {
+        return $this->from;
+    }
+
+    public function getTo(): DateTimeImmutable
+    {
+        return $this->to;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetRegistered.php
+++ b/availability/simple-availability/src/Events/AssetRegistered.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+
+final readonly class AssetRegistered extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_REGISTERED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetRegistered.php
+++ b/availability/simple-availability/src/Events/AssetRegistered.php
@@ -8,7 +8,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 
 final readonly class AssetRegistered extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_REGISTERED';
+    public const string TYPE = 'ASSET_REGISTERED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetRegistrationRejected.php
+++ b/availability/simple-availability/src/Events/AssetRegistrationRejected.php
@@ -8,7 +8,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 
 final readonly class AssetRegistrationRejected extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_REGISTRATION_REJECTED';
+    public const string TYPE = 'ASSET_REGISTRATION_REJECTED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetRegistrationRejected.php
+++ b/availability/simple-availability/src/Events/AssetRegistrationRejected.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+
+final readonly class AssetRegistrationRejected extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_REGISTRATION_REJECTED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId,
+        private string $reason
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId, string $reason): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId,
+            $reason
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetUnlocked.php
+++ b/availability/simple-availability/src/Events/AssetUnlocked.php
@@ -9,7 +9,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
 
 final readonly class AssetUnlocked extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_UNLOCKED';
+    public const string TYPE = 'ASSET_UNLOCKED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetUnlocked.php
+++ b/availability/simple-availability/src/Events/AssetUnlocked.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+
+final readonly class AssetUnlocked extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_UNLOCKED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId,
+        private OwnerId $ownerId
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId, OwnerId $ownerId): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId,
+            $ownerId
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getOwnerId(): OwnerId
+    {
+        return $this->ownerId;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetUnlockingRejected.php
+++ b/availability/simple-availability/src/Events/AssetUnlockingRejected.php
@@ -9,7 +9,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
 
 final readonly class AssetUnlockingRejected extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_UNLOCKING_REJECTED';
+    public const string TYPE = 'ASSET_UNLOCKING_REJECTED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetUnlockingRejected.php
+++ b/availability/simple-availability/src/Events/AssetUnlockingRejected.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+
+final readonly class AssetUnlockingRejected extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_UNLOCKING_REJECTED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId,
+        private OwnerId $ownerId,
+        private string $reason
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId, OwnerId $ownerId, string $reason): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId,
+            $ownerId,
+            $reason
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getOwnerId(): OwnerId
+    {
+        return $this->ownerId;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetWithdrawalRejected.php
+++ b/availability/simple-availability/src/Events/AssetWithdrawalRejected.php
@@ -8,7 +8,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 
 final readonly class AssetWithdrawalRejected extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_WITHDRAWAL_REJECTED';
+    public const string TYPE = 'ASSET_WITHDRAWAL_REJECTED';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetWithdrawalRejected.php
+++ b/availability/simple-availability/src/Events/AssetWithdrawalRejected.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+
+final readonly class AssetWithdrawalRejected extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_WITHDRAWAL_REJECTED';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId,
+        private string $reason
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId, string $reason): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId,
+            $reason
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/AssetWithdrawn.php
+++ b/availability/simple-availability/src/Events/AssetWithdrawn.php
@@ -8,7 +8,7 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 
 final readonly class AssetWithdrawn extends BaseDomainEvent
 {
-    public const TYPE = 'ASSET_WITHDRAWN';
+    public const string TYPE = 'ASSET_WITHDRAWN';
 
     private function __construct(
         string $id,

--- a/availability/simple-availability/src/Events/AssetWithdrawn.php
+++ b/availability/simple-availability/src/Events/AssetWithdrawn.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+
+final readonly class AssetWithdrawn extends BaseDomainEvent
+{
+    public const TYPE = 'ASSET_WITHDRAWN';
+
+    private function __construct(
+        string $id,
+        \DateTimeImmutable $occurredAt,
+        private AssetId $assetId
+    ) {
+        parent::__construct($id, $occurredAt);
+    }
+
+    public static function from(AssetId $assetId): self
+    {
+        return new self(
+            self::generateId(),
+            self::now(),
+            $assetId
+        );
+    }
+
+    public function getAssetId(): AssetId
+    {
+        return $this->assetId;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/availability/simple-availability/src/Events/BaseDomainEvent.php
+++ b/availability/simple-availability/src/Events/BaseDomainEvent.php
@@ -31,8 +31,11 @@ abstract readonly class BaseDomainEvent implements DomainEvent
         return bin2hex(random_bytes(16));
     }
 
-    protected static function now(): DateTimeImmutable
+    protected static function now(?\SoftwareArchetypes\Availability\SimpleAvailability\Common\Clock $clock = null): DateTimeImmutable
     {
-        return new DateTimeImmutable();
+        if ($clock === null) {
+            return new DateTimeImmutable();
+        }
+        return $clock->now();
     }
 }

--- a/availability/simple-availability/src/Events/BaseDomainEvent.php
+++ b/availability/simple-availability/src/Events/BaseDomainEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use DateTimeImmutable;
+
+abstract readonly class BaseDomainEvent implements DomainEvent
+{
+    public function __construct(
+        private string $id,
+        private DateTimeImmutable $occurredAt
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getOccurredAt(): DateTimeImmutable
+    {
+        return $this->occurredAt;
+    }
+
+    abstract public function getType(): string;
+
+    protected static function generateId(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+
+    protected static function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/availability/simple-availability/src/Events/DomainEvent.php
+++ b/availability/simple-availability/src/Events/DomainEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+use DateTimeImmutable;
+
+interface DomainEvent
+{
+    public function getId(): string;
+
+    public function getOccurredAt(): DateTimeImmutable;
+
+    public function getType(): string;
+}

--- a/availability/simple-availability/src/Events/DomainEventsPublisher.php
+++ b/availability/simple-availability/src/Events/DomainEventsPublisher.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Events;
+
+interface DomainEventsPublisher
+{
+    public function publish(DomainEvent $event): void;
+}

--- a/availability/simple-availability/src/Infrastructure/EventPublisher/InMemoryDomainEventsPublisher.php
+++ b/availability/simple-availability/src/Infrastructure/EventPublisher/InMemoryDomainEventsPublisher.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\EventPublisher;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\DomainEvent;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\DomainEventsPublisher;
+
+class InMemoryDomainEventsPublisher implements DomainEventsPublisher
+{
+    /**
+     * @var array<DomainEvent>
+     */
+    private array $events = [];
+
+    public function publish(DomainEvent $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /**
+     * @return array<DomainEvent>
+     */
+    public function getPublishedEvents(): array
+    {
+        return $this->events;
+    }
+
+    public function clear(): void
+    {
+        $this->events = [];
+    }
+
+    /**
+     * @template T of DomainEvent
+     * @param class-string<T> $eventClass
+     * @return array<T>
+     */
+    public function getEventsOfType(string $eventClass): array
+    {
+        return array_filter(
+            $this->events,
+            fn($event) => $event instanceof $eventClass
+        );
+    }
+
+    public function hasEvent(string $eventClass): bool
+    {
+        return !empty($this->getEventsOfType($eventClass));
+    }
+}

--- a/availability/simple-availability/src/Infrastructure/EventPublisher/InMemoryDomainEventsPublisher.php
+++ b/availability/simple-availability/src/Infrastructure/EventPublisher/InMemoryDomainEventsPublisher.php
@@ -45,6 +45,9 @@ class InMemoryDomainEventsPublisher implements DomainEventsPublisher
         );
     }
 
+    /**
+     * @param class-string<DomainEvent> $eventClass
+     */
     public function hasEvent(string $eventClass): bool
     {
         return !empty($this->getEventsOfType($eventClass));

--- a/availability/simple-availability/src/Infrastructure/Repository/InMemoryAssetAvailabilityRepository.php
+++ b/availability/simple-availability/src/Infrastructure/Repository/InMemoryAssetAvailabilityRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\Repository;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailabilityRepository;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+
+class InMemoryAssetAvailabilityRepository implements AssetAvailabilityRepository
+{
+    /**
+     * @var array<string, AssetAvailability>
+     */
+    private array $storage = [];
+
+    public function save(AssetAvailability $assetAvailability): void
+    {
+        $this->storage[$assetAvailability->id()->asString()] = $assetAvailability;
+    }
+
+    public function findById(AssetId $assetId): ?AssetAvailability
+    {
+        return $this->storage[$assetId->asString()] ?? null;
+    }
+
+    public function existsById(AssetId $assetId): bool
+    {
+        return isset($this->storage[$assetId->asString()]);
+    }
+
+    public function clear(): void
+    {
+        $this->storage = [];
+    }
+
+    /**
+     * @return array<AssetAvailability>
+     */
+    public function findAll(): array
+    {
+        return array_values($this->storage);
+    }
+}

--- a/availability/simple-availability/tests/Application/AvailabilityServiceTest.php
+++ b/availability/simple-availability/tests/Application/AvailabilityServiceTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Application;
+
+use DateInterval;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use SoftwareArchetypes\Availability\SimpleAvailability\Application\AvailabilityService;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivated;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetRegistered;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetRegistrationRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetUnlocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawn;
+use SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\EventPublisher\InMemoryDomainEventsPublisher;
+use SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\Repository\InMemoryAssetAvailabilityRepository;
+
+class AvailabilityServiceTest extends TestCase
+{
+    private AvailabilityService $service;
+    private InMemoryAssetAvailabilityRepository $repository;
+    private InMemoryDomainEventsPublisher $eventsPublisher;
+
+    protected function setUp(): void
+    {
+        $this->repository = new InMemoryAssetAvailabilityRepository();
+        $this->eventsPublisher = new InMemoryDomainEventsPublisher();
+        $this->service = new AvailabilityService($this->repository, $this->eventsPublisher);
+    }
+
+    public function testCanRegisterNewAsset(): void
+    {
+        $assetId = AssetId::of('asset-123');
+
+        $result = $this->service->registerAssetWith($assetId);
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetRegistered::class, $result->getSuccess());
+        $this->assertTrue($this->eventsPublisher->hasEvent(AssetRegistered::class));
+        $this->assertNotNull($this->repository->findById($assetId));
+    }
+
+    public function testCannotRegisterDuplicateAsset(): void
+    {
+        $assetId = AssetId::of('asset-123');
+        $this->service->registerAssetWith($assetId);
+
+        $result = $this->service->registerAssetWith($assetId);
+
+        $this->assertTrue($result->isFailure());
+        $this->assertInstanceOf(AssetRegistrationRejected::class, $result->getFailure());
+    }
+
+    public function testCanActivateRegisteredAsset(): void
+    {
+        $assetId = AssetId::of('asset-123');
+        $this->service->registerAssetWith($assetId);
+
+        $result = $this->service->activate($assetId);
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetActivated::class, $result->getSuccess());
+        $this->assertTrue($this->eventsPublisher->hasEvent(AssetActivated::class));
+    }
+
+    public function testCanWithdrawAsset(): void
+    {
+        $assetId = AssetId::of('asset-123');
+        $this->service->registerAssetWith($assetId);
+        $this->service->activate($assetId);
+
+        $result = $this->service->withdraw($assetId);
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetWithdrawn::class, $result->getSuccess());
+        $this->assertTrue($this->eventsPublisher->hasEvent(AssetWithdrawn::class));
+    }
+
+    public function testCanLockAsset(): void
+    {
+        $assetId = AssetId::of('asset-123');
+        $ownerId = OwnerId::of('owner-456');
+        $this->service->registerAssetWith($assetId);
+        $this->service->activate($assetId);
+
+        $result = $this->service->lock($assetId, $ownerId, new DateInterval('PT30M'));
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetLocked::class, $result->getSuccess());
+        $this->assertTrue($this->eventsPublisher->hasEvent(AssetLocked::class));
+    }
+
+    public function testCanUnlockAsset(): void
+    {
+        $assetId = AssetId::of('asset-123');
+        $ownerId = OwnerId::of('owner-456');
+        $this->service->registerAssetWith($assetId);
+        $this->service->activate($assetId);
+        $this->service->lock($assetId, $ownerId, new DateInterval('PT30M'));
+
+        $result = $this->service->unlock($assetId, $ownerId, new DateTimeImmutable());
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetUnlocked::class, $result->getSuccess());
+        $this->assertTrue($this->eventsPublisher->hasEvent(AssetUnlocked::class));
+    }
+
+    public function testCanLockIndefinitely(): void
+    {
+        $assetId = AssetId::of('asset-123');
+        $ownerId = OwnerId::of('owner-456');
+        $this->service->registerAssetWith($assetId);
+        $this->service->activate($assetId);
+        $this->service->lock($assetId, $ownerId, new DateInterval('PT30M'));
+
+        $result = $this->service->lockIndefinitely($assetId, $ownerId);
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetLocked::class, $result->getSuccess());
+    }
+
+    public function testCompleteWorkflow(): void
+    {
+        $assetId = AssetId::of('asset-workflow');
+        $ownerId = OwnerId::of('owner-workflow');
+
+        // Register
+        $result = $this->service->registerAssetWith($assetId);
+        $this->assertTrue($result->isSuccess());
+
+        // Activate
+        $result = $this->service->activate($assetId);
+        $this->assertTrue($result->isSuccess());
+
+        // Lock
+        $result = $this->service->lock($assetId, $ownerId, new DateInterval('PT1H'));
+        $this->assertTrue($result->isSuccess());
+
+        // Unlock
+        $result = $this->service->unlock($assetId, $ownerId, new DateTimeImmutable());
+        $this->assertTrue($result->isSuccess());
+
+        // Withdraw
+        $result = $this->service->withdraw($assetId);
+        $this->assertTrue($result->isSuccess());
+    }
+}

--- a/availability/simple-availability/tests/Application/AvailabilityServiceTest.php
+++ b/availability/simple-availability/tests/Application/AvailabilityServiceTest.php
@@ -8,6 +8,7 @@ use DateInterval;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use SoftwareArchetypes\Availability\SimpleAvailability\Application\AvailabilityService;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\SystemClock;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
 use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivated;
@@ -29,7 +30,7 @@ class AvailabilityServiceTest extends TestCase
     {
         $this->repository = new InMemoryAssetAvailabilityRepository();
         $this->eventsPublisher = new InMemoryDomainEventsPublisher();
-        $this->service = new AvailabilityService($this->repository, $this->eventsPublisher);
+        $this->service = new AvailabilityService($this->repository, $this->eventsPublisher, new SystemClock());
     }
 
     public function testCanRegisterNewAsset(): void

--- a/availability/simple-availability/tests/Common/ResultTest.php
+++ b/availability/simple-availability/tests/Common/ResultTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Common;
+
+use PHPUnit\Framework\TestCase;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Result;
+
+class ResultTest extends TestCase
+{
+    public function testSuccessCreation(): void
+    {
+        $result = Result::success('success value');
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertFalse($result->isFailure());
+        $this->assertEquals('success value', $result->getSuccess());
+    }
+
+    public function testFailureCreation(): void
+    {
+        $result = Result::failure('failure value');
+
+        $this->assertTrue($result->isFailure());
+        $this->assertFalse($result->isSuccess());
+        $this->assertEquals('failure value', $result->getFailure());
+    }
+
+    public function testMapOnSuccess(): void
+    {
+        $result = Result::success(10);
+
+        $mapped = $result->map(fn($x) => $x * 2);
+
+        $this->assertTrue($mapped->isSuccess());
+        $this->assertEquals(20, $mapped->getSuccess());
+    }
+
+    public function testMapOnFailure(): void
+    {
+        $result = Result::failure('error');
+
+        $mapped = $result->map(fn($x) => $x * 2);
+
+        $this->assertTrue($mapped->isFailure());
+        $this->assertEquals('error', $mapped->getFailure());
+    }
+
+    public function testMapFailureOnSuccess(): void
+    {
+        $result = Result::success('success');
+
+        $mapped = $result->mapFailure(fn($x) => strtoupper($x));
+
+        $this->assertTrue($mapped->isSuccess());
+        $this->assertEquals('success', $mapped->getSuccess());
+    }
+
+    public function testMapFailureOnFailure(): void
+    {
+        $result = Result::failure('error');
+
+        $mapped = $result->mapFailure(fn($x) => strtoupper($x));
+
+        $this->assertTrue($mapped->isFailure());
+        $this->assertEquals('ERROR', $mapped->getFailure());
+    }
+
+    public function testFlatMapOnSuccess(): void
+    {
+        $result = Result::success(10);
+
+        $flatMapped = $result->flatMap(fn($x) => Result::success($x * 2));
+
+        $this->assertTrue($flatMapped->isSuccess());
+        $this->assertEquals(20, $flatMapped->getSuccess());
+    }
+
+    public function testFlatMapOnFailure(): void
+    {
+        $result = Result::failure('error');
+
+        $flatMapped = $result->flatMap(fn($x) => Result::success($x * 2));
+
+        $this->assertTrue($flatMapped->isFailure());
+        $this->assertEquals('error', $flatMapped->getFailure());
+    }
+
+    public function testFold(): void
+    {
+        $success = Result::success(10);
+        $failure = Result::failure('error');
+
+        $successResult = $success->fold(
+            fn($x) => "Success: $x",
+            fn($x) => "Failure: $x"
+        );
+
+        $failureResult = $failure->fold(
+            fn($x) => "Success: $x",
+            fn($x) => "Failure: $x"
+        );
+
+        $this->assertEquals('Success: 10', $successResult);
+        $this->assertEquals('Failure: error', $failureResult);
+    }
+
+    public function testPeekOnSuccess(): void
+    {
+        $called = false;
+        $result = Result::success('value');
+
+        $result->peek(function ($x) use (&$called) {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
+    }
+
+    public function testPeekOnFailure(): void
+    {
+        $called = false;
+        $result = Result::failure('error');
+
+        $result->peek(function ($x) use (&$called) {
+            $called = true;
+        });
+
+        $this->assertFalse($called);
+    }
+
+    public function testPeekFailureOnSuccess(): void
+    {
+        $called = false;
+        $result = Result::success('value');
+
+        $result->peekFailure(function ($x) use (&$called) {
+            $called = true;
+        });
+
+        $this->assertFalse($called);
+    }
+
+    public function testPeekFailureOnFailure(): void
+    {
+        $called = false;
+        $result = Result::failure('error');
+
+        $result->peekFailure(function ($x) use (&$called) {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
+    }
+
+    public function testBiMap(): void
+    {
+        $success = Result::success(10);
+        $failure = Result::failure('error');
+
+        $mappedSuccess = $success->biMap(
+            fn($x) => $x * 2,
+            fn($x) => strtoupper($x)
+        );
+
+        $mappedFailure = $failure->biMap(
+            fn($x) => $x * 2,
+            fn($x) => strtoupper($x)
+        );
+
+        $this->assertTrue($mappedSuccess->isSuccess());
+        $this->assertEquals(20, $mappedSuccess->getSuccess());
+
+        $this->assertTrue($mappedFailure->isFailure());
+        $this->assertEquals('ERROR', $mappedFailure->getFailure());
+    }
+}

--- a/availability/simple-availability/tests/Domain/AssetAvailabilityTest.php
+++ b/availability/simple-availability/tests/Domain/AssetAvailabilityTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Domain;
+
+use DateInterval;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\MaintenanceLock;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerLock;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\WithdrawalLock;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivated;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetActivationRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLockRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetUnlocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetUnlockingRejected;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawn;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawalRejected;
+
+class AssetAvailabilityTest extends TestCase
+{
+    private AssetId $assetId;
+    private OwnerId $ownerId;
+
+    protected function setUp(): void
+    {
+        $this->assetId = AssetId::of('asset-123');
+        $this->ownerId = OwnerId::of('owner-456');
+    }
+
+    public function testNewAssetHasMaintenanceLock(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+
+        $lock = $asset->currentLock();
+        $this->assertInstanceOf(MaintenanceLock::class, $lock);
+    }
+
+    public function testCanActivateAssetWithMaintenanceLock(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+
+        $result = $asset->activate();
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetActivated::class, $result->getSuccess());
+        $this->assertNull($asset->currentLock());
+    }
+
+    public function testCannotActivateAlreadyActivatedAsset(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+
+        $result = $asset->activate();
+
+        $this->assertTrue($result->isFailure());
+        $this->assertInstanceOf(AssetActivationRejected::class, $result->getFailure());
+    }
+
+    public function testCanWithdrawAvailableAsset(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+
+        $result = $asset->withdraw();
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetWithdrawn::class, $result->getSuccess());
+        $this->assertInstanceOf(WithdrawalLock::class, $asset->currentLock());
+    }
+
+    public function testCannotWithdrawLockedAsset(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+        $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
+
+        $result = $asset->withdraw();
+
+        $this->assertTrue($result->isFailure());
+        $this->assertInstanceOf(AssetWithdrawalRejected::class, $result->getFailure());
+    }
+
+    public function testCanLockAvailableAsset(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+
+        $result = $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetLocked::class, $result->getSuccess());
+        $this->assertInstanceOf(OwnerLock::class, $asset->currentLock());
+    }
+
+    public function testCannotLockAlreadyLockedAsset(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+        $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
+
+        $anotherOwner = OwnerId::of('another-owner');
+        $result = $asset->lockFor($anotherOwner, new DateInterval('PT30M'));
+
+        $this->assertTrue($result->isFailure());
+        $this->assertInstanceOf(AssetLockRejected::class, $result->getFailure());
+    }
+
+    public function testCanLockIndefinitelyForExistingOwner(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+        $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
+
+        $result = $asset->lockIndefinitelyFor($this->ownerId);
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetLocked::class, $result->getSuccess());
+    }
+
+    public function testCannotLockIndefinitelyWithoutExistingLock(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+
+        $result = $asset->lockIndefinitelyFor($this->ownerId);
+
+        $this->assertTrue($result->isFailure());
+        $this->assertInstanceOf(AssetLockRejected::class, $result->getFailure());
+    }
+
+    public function testCanUnlockAssetByOwner(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+        $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
+
+        $result = $asset->unlockFor($this->ownerId, new DateTimeImmutable());
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertInstanceOf(AssetUnlocked::class, $result->getSuccess());
+        $this->assertNull($asset->currentLock());
+    }
+
+    public function testCannotUnlockAssetByDifferentOwner(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+        $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
+
+        $anotherOwner = OwnerId::of('another-owner');
+        $result = $asset->unlockFor($anotherOwner, new DateTimeImmutable());
+
+        $this->assertTrue($result->isFailure());
+        $this->assertInstanceOf(AssetUnlockingRejected::class, $result->getFailure());
+    }
+
+    public function testUnlockIfOverdueRemovesOwnerLock(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+        $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
+
+        $event = $asset->unlockIfOverdue();
+
+        $this->assertNotNull($event);
+        $this->assertNull($asset->currentLock());
+    }
+
+    public function testUnlockIfOverdueReturnsNullWhenNoOwnerLock(): void
+    {
+        $asset = AssetAvailability::of($this->assetId);
+        $asset->activate();
+
+        $event = $asset->unlockIfOverdue();
+
+        $this->assertNull($event);
+    }
+}

--- a/availability/simple-availability/tests/Domain/AssetAvailabilityTest.php
+++ b/availability/simple-availability/tests/Domain/AssetAvailabilityTest.php
@@ -7,6 +7,7 @@ namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Domain;
 use DateInterval;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\SystemClock;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\MaintenanceLock;
@@ -35,7 +36,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testNewAssetHasMaintenanceLock(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
 
         $lock = $asset->currentLock();
         $this->assertInstanceOf(MaintenanceLock::class, $lock);
@@ -43,7 +44,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCanActivateAssetWithMaintenanceLock(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
 
         $result = $asset->activate();
 
@@ -54,7 +55,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCannotActivateAlreadyActivatedAsset(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
 
         $result = $asset->activate();
@@ -65,7 +66,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCanWithdrawAvailableAsset(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
 
         $result = $asset->withdraw();
@@ -77,7 +78,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCannotWithdrawLockedAsset(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
         $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
 
@@ -89,7 +90,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCanLockAvailableAsset(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
 
         $result = $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
@@ -101,7 +102,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCannotLockAlreadyLockedAsset(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
         $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
 
@@ -114,7 +115,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCanLockIndefinitelyForExistingOwner(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
         $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
 
@@ -126,7 +127,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCannotLockIndefinitelyWithoutExistingLock(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
 
         $result = $asset->lockIndefinitelyFor($this->ownerId);
@@ -137,7 +138,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCanUnlockAssetByOwner(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
         $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
 
@@ -150,7 +151,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testCannotUnlockAssetByDifferentOwner(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
         $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
 
@@ -163,7 +164,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testUnlockIfOverdueRemovesOwnerLock(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
         $asset->lockFor($this->ownerId, new DateInterval('PT30M'));
 
@@ -175,7 +176,7 @@ class AssetAvailabilityTest extends TestCase
 
     public function testUnlockIfOverdueReturnsNullWhenNoOwnerLock(): void
     {
-        $asset = AssetAvailability::of($this->assetId);
+        $asset = AssetAvailability::of($this->assetId, new SystemClock());
         $asset->activate();
 
         $event = $asset->unlockIfOverdue();

--- a/availability/simple-availability/tests/Fixtures/AssetAvailabilityFixture.php
+++ b/availability/simple-availability/tests/Fixtures/AssetAvailabilityFixture.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Fixtures;
+
+use DateInterval;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+
+class AssetAvailabilityFixture
+{
+    private ?AssetId $assetId = null;
+    private bool $shouldActivate = false;
+    private ?OwnerId $lockOwnerId = null;
+    private ?DateInterval $lockDuration = null;
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function withAssetId(AssetId $assetId): self
+    {
+        $this->assetId = $assetId;
+        return $this;
+    }
+
+    public function thatIsActive(): self
+    {
+        $this->shouldActivate = true;
+        return $this;
+    }
+
+    public function thatWasLockedByOwnerWith(OwnerId $ownerId): self
+    {
+        $this->lockOwnerId = $ownerId;
+        return $this;
+    }
+
+    public function thatWasLockedBySomeOwner(): self
+    {
+        $this->lockOwnerId = OwnerId::of('SOME_OWNER_' . bin2hex(random_bytes(4)));
+        return $this;
+    }
+
+    public function forSomeValidDuration(): self
+    {
+        $this->lockDuration = new DateInterval('PT30M');
+        return $this;
+    }
+
+    public function forDuration(DateInterval $duration): self
+    {
+        $this->lockDuration = $duration;
+        return $this;
+    }
+
+    public function get(): AssetAvailability
+    {
+        $assetId = $this->assetId ?? AssetId::of('asset-' . bin2hex(random_bytes(8)));
+        $asset = AssetAvailability::of($assetId);
+
+        if ($this->shouldActivate) {
+            $asset->activate();
+        }
+
+        if ($this->lockOwnerId !== null && $this->lockDuration !== null) {
+            $asset->lockFor($this->lockOwnerId, $this->lockDuration);
+        }
+
+        return $asset;
+    }
+
+    public static function someAssetIdValue(): string
+    {
+        return 'asset-' . bin2hex(random_bytes(8));
+    }
+
+    public static function someValidDuration(): DateInterval
+    {
+        return new DateInterval('PT30M');
+    }
+
+    public static function someNewAsset(): AssetAvailability
+    {
+        return AssetAvailability::of(AssetId::of(self::someAssetIdValue()));
+    }
+}

--- a/availability/simple-availability/tests/Fixtures/AssetAvailabilityFixture.php
+++ b/availability/simple-availability/tests/Fixtures/AssetAvailabilityFixture.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Fixtures;
 
 use DateInterval;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Clock;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\SystemClock;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
@@ -15,10 +17,13 @@ class AssetAvailabilityFixture
     private bool $shouldActivate = false;
     private ?OwnerId $lockOwnerId = null;
     private ?DateInterval $lockDuration = null;
+    private ?Clock $clock = null;
 
-    public static function create(): self
+    public static function create(?Clock $clock = null): self
     {
-        return new self();
+        $fixture = new self();
+        $fixture->clock = $clock ?? new SystemClock();
+        return $fixture;
     }
 
     public function withAssetId(AssetId $assetId): self
@@ -60,7 +65,8 @@ class AssetAvailabilityFixture
     public function get(): AssetAvailability
     {
         $assetId = $this->assetId ?? AssetId::of('asset-' . bin2hex(random_bytes(8)));
-        $asset = AssetAvailability::of($assetId);
+        $clock = $this->clock ?? new SystemClock();
+        $asset = AssetAvailability::of($assetId, $clock);
 
         if ($this->shouldActivate) {
             $asset->activate();
@@ -83,8 +89,9 @@ class AssetAvailabilityFixture
         return new DateInterval('PT30M');
     }
 
-    public static function someNewAsset(): AssetAvailability
+    public static function someNewAsset(?Clock $clock = null): AssetAvailability
     {
-        return AssetAvailability::of(AssetId::of(self::someAssetIdValue()));
+        $clock = $clock ?? new SystemClock();
+        return AssetAvailability::of(AssetId::of(self::someAssetIdValue()), $clock);
     }
 }

--- a/availability/simple-availability/tests/Integration/AvailabilityServiceIntegrationTest.php
+++ b/availability/simple-availability/tests/Integration/AvailabilityServiceIntegrationTest.php
@@ -8,6 +8,8 @@ use DateInterval;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use SoftwareArchetypes\Availability\SimpleAvailability\Application\AvailabilityService;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Clock;
+use SoftwareArchetypes\Availability\SimpleAvailability\Tests\Support\MockClock;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
 use SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\EventPublisher\InMemoryDomainEventsPublisher;
@@ -23,17 +25,24 @@ class AvailabilityServiceIntegrationTest extends TestCase
 
     private AvailabilityService $service;
     private InMemoryAssetAvailabilityRepository $repository;
+    private MockClock $clock;
 
     protected function setUp(): void
     {
         $this->repository = new InMemoryAssetAvailabilityRepository();
         $this->setupEventPublisher();
-        $this->service = new AvailabilityService($this->repository, $this->eventPublisher);
+        $this->clock = new MockClock();
+        $this->service = new AvailabilityService($this->repository, $this->eventPublisher, $this->clock);
     }
 
     protected function getRepository(): InMemoryAssetAvailabilityRepository
     {
         return $this->repository;
+    }
+
+    protected function getClock(): Clock
+    {
+        return $this->clock;
     }
 
     // REGISTRATION TESTS

--- a/availability/simple-availability/tests/Integration/AvailabilityServiceIntegrationTest.php
+++ b/availability/simple-availability/tests/Integration/AvailabilityServiceIntegrationTest.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Integration;
+
+use DateInterval;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use SoftwareArchetypes\Availability\SimpleAvailability\Application\AvailabilityService;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\EventPublisher\InMemoryDomainEventsPublisher;
+use SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\Repository\InMemoryAssetAvailabilityRepository;
+use SoftwareArchetypes\Availability\SimpleAvailability\Tests\Fixtures\AssetAvailabilityFixture;
+use SoftwareArchetypes\Availability\SimpleAvailability\Tests\Support\AssetAvailabilityEventsSupport;
+use SoftwareArchetypes\Availability\SimpleAvailability\Tests\Support\AssetAvailabilityStoreSupport;
+
+class AvailabilityServiceIntegrationTest extends TestCase
+{
+    use AssetAvailabilityStoreSupport;
+    use AssetAvailabilityEventsSupport;
+
+    private AvailabilityService $service;
+    private InMemoryAssetAvailabilityRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = new InMemoryAssetAvailabilityRepository();
+        $this->setupEventPublisher();
+        $this->service = new AvailabilityService($this->repository, $this->eventPublisher);
+    }
+
+    protected function getRepository(): InMemoryAssetAvailabilityRepository
+    {
+        return $this->repository;
+    }
+
+    // REGISTRATION TESTS
+
+    public function testShouldAcceptRegistrationOfNewAsset(): void
+    {
+        // given
+        $assetId = AssetId::of(AssetAvailabilityFixture::someAssetIdValue());
+
+        // when
+        $result = $this->service->registerAssetWith($assetId);
+
+        // then
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->assetIsRegisteredWith($assetId));
+        $this->assertTrue($this->assetRegisteredEventWasPublishedFor($assetId));
+    }
+
+    public function testShouldRejectRegistrationOfAlreadyExistingAsset(): void
+    {
+        // given
+        $asset = $this->existingAsset();
+
+        // when
+        $result = $this->service->registerAssetWith($asset->id());
+
+        // then
+        $this->assertTrue($result->isFailure());
+    }
+
+    // WITHDRAWAL TESTS
+
+    public function testShouldAcceptWithdrawalOfExistingAsset(): void
+    {
+        // given
+        $asset = $this->existingAsset();
+
+        // when
+        $result = $this->service->withdraw($asset->id());
+
+        // then
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->thereIsAWithdrawnAssetWith($asset->id()));
+        $this->assertTrue($this->assetWithdrawnEventWasPublishedFor($asset->id()));
+    }
+
+    public function testShouldRejectWithdrawalOfLockedAsset(): void
+    {
+        // given
+        $asset = $this->lockedAsset();
+
+        // when
+        $result = $this->service->withdraw($asset->id());
+
+        // then
+        $this->assertTrue($result->isFailure());
+    }
+
+    // ACTIVATION TESTS
+
+    public function testShouldAcceptActivationOfRegisteredAsset(): void
+    {
+        // given
+        $asset = $this->existingAsset();
+
+        // when
+        $result = $this->service->activate($asset->id());
+
+        // then
+        $this->assertTrue($result->isSuccess());
+    }
+
+    public function testShouldRejectActivationOfNotExistingAsset(): void
+    {
+        // given
+        $idOfNotExistingAsset = AssetId::of(AssetAvailabilityFixture::someAssetIdValue());
+
+        // when
+        $result = $this->service->activate($idOfNotExistingAsset);
+
+        // then
+        $this->assertTrue($result->isFailure());
+    }
+
+    // LOCKING TESTS
+
+    public function testShouldAcceptLockingOfActivatedAsset(): void
+    {
+        // given
+        $asset = $this->activatedAsset();
+        $ownerId = OwnerId::of('ADAM_123');
+        $duration = AssetAvailabilityFixture::someValidDuration();
+
+        // when
+        $result = $this->service->lock($asset->id(), $ownerId, $duration);
+
+        // then
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->thereIsALockedAssetWith($asset->id(), $ownerId));
+        $this->assertTrue($this->assetLockedEventWasPublishedFor($asset->id(), $ownerId));
+    }
+
+    public function testShouldRejectLockingOfAlreadyLockedAsset(): void
+    {
+        // given
+        $asset = $this->lockedAsset();
+        $anotherOwnerId = OwnerId::of('ADAM_123');
+        $duration = AssetAvailabilityFixture::someValidDuration();
+
+        // when
+        $result = $this->service->lock($asset->id(), $anotherOwnerId, $duration);
+
+        // then
+        $this->assertTrue($result->isFailure());
+    }
+
+    public function testShouldAcceptIndefiniteLockingOfAlreadyLockedAsset(): void
+    {
+        // given
+        $ownerId = OwnerId::of('ADAM_123');
+        $asset = $this->assetLockedBy($ownerId);
+
+        // when
+        $result = $this->service->lockIndefinitely($asset->id(), $ownerId);
+
+        // then
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->thereIsALockedAssetWith($asset->id(), $ownerId));
+        $this->assertTrue($this->assetLockedEventWasPublishedFor($asset->id(), $ownerId));
+    }
+
+    public function testShouldRejectIndefiniteLockingOfAssetLockedBySomeoneElse(): void
+    {
+        // given
+        $asset = $this->lockedAsset();
+        $differentOwnerId = OwnerId::of('ADAM_123');
+
+        // when
+        $result = $this->service->lockIndefinitely($asset->id(), $differentOwnerId);
+
+        // then
+        $this->assertTrue($result->isFailure());
+    }
+
+    // UNLOCKING TESTS
+
+    public function testShouldAcceptUnlockingOfAlreadyLockedAsset(): void
+    {
+        // given
+        $ownerId = OwnerId::of('ADAM_123');
+        $asset = $this->assetLockedBy($ownerId);
+        $at = new DateTimeImmutable();
+
+        // when
+        $result = $this->service->unlock($asset->id(), $ownerId, $at);
+
+        // then
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->thereIsAnUnlockedAssetWith($asset->id()));
+        $this->assertTrue($this->assetUnlockedEventWasPublishedFor($asset->id(), $ownerId));
+    }
+
+    public function testShouldRejectUnlockingOfAssetLockedBySomeoneElse(): void
+    {
+        // given
+        $asset = $this->lockedAsset();
+        $differentOwnerId = OwnerId::of('ADAM_123');
+        $at = new DateTimeImmutable();
+
+        // when
+        $result = $this->service->unlock($asset->id(), $differentOwnerId, $at);
+
+        // then
+        $this->assertTrue($result->isFailure());
+    }
+
+    // COMPLEX WORKFLOW TESTS
+
+    public function testCompleteAssetLifecycleWorkflow(): void
+    {
+        // Register
+        $assetId = AssetId::of(AssetAvailabilityFixture::someAssetIdValue());
+        $result = $this->service->registerAssetWith($assetId);
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->assetIsRegisteredWith($assetId));
+
+        // Activate
+        $result = $this->service->activate($assetId);
+        $this->assertTrue($result->isSuccess());
+
+        // Lock by first owner
+        $ownerId1 = OwnerId::of('OWNER_1');
+        $result = $this->service->lock($assetId, $ownerId1, new DateInterval('PT1H'));
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->thereIsALockedAssetWith($assetId, $ownerId1));
+
+        // Try to lock by second owner (should fail)
+        $ownerId2 = OwnerId::of('OWNER_2');
+        $result = $this->service->lock($assetId, $ownerId2, new DateInterval('PT1H'));
+        $this->assertTrue($result->isFailure());
+
+        // Lock indefinitely by same owner (should succeed)
+        $result = $this->service->lockIndefinitely($assetId, $ownerId1);
+        $this->assertTrue($result->isSuccess());
+
+        // Unlock by owner
+        $result = $this->service->unlock($assetId, $ownerId1, new DateTimeImmutable());
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->thereIsAnUnlockedAssetWith($assetId));
+
+        // Withdraw
+        $result = $this->service->withdraw($assetId);
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($this->thereIsAWithdrawnAssetWith($assetId));
+    }
+
+    public function testMultipleAssetsCanBeManagedIndependently(): void
+    {
+        // Register three assets
+        $assetId1 = AssetId::of(AssetAvailabilityFixture::someAssetIdValue());
+        $assetId2 = AssetId::of(AssetAvailabilityFixture::someAssetIdValue());
+        $assetId3 = AssetId::of(AssetAvailabilityFixture::someAssetIdValue());
+
+        $this->service->registerAssetWith($assetId1);
+        $this->service->registerAssetWith($assetId2);
+        $this->service->registerAssetWith($assetId3);
+
+        // Activate all
+        $this->service->activate($assetId1);
+        $this->service->activate($assetId2);
+        $this->service->activate($assetId3);
+
+        // Lock by different owners
+        $owner1 = OwnerId::of('OWNER_1');
+        $owner2 = OwnerId::of('OWNER_2');
+        $owner3 = OwnerId::of('OWNER_3');
+
+        $result1 = $this->service->lock($assetId1, $owner1, new DateInterval('PT30M'));
+        $result2 = $this->service->lock($assetId2, $owner2, new DateInterval('PT30M'));
+        $result3 = $this->service->lock($assetId3, $owner3, new DateInterval('PT30M'));
+
+        $this->assertTrue($result1->isSuccess());
+        $this->assertTrue($result2->isSuccess());
+        $this->assertTrue($result3->isSuccess());
+
+        // Verify each asset is locked by its owner
+        $this->assertTrue($this->thereIsALockedAssetWith($assetId1, $owner1));
+        $this->assertTrue($this->thereIsALockedAssetWith($assetId2, $owner2));
+        $this->assertTrue($this->thereIsALockedAssetWith($assetId3, $owner3));
+
+        // Unlock asset 2
+        $result = $this->service->unlock($assetId2, $owner2, new DateTimeImmutable());
+        $this->assertTrue($result->isSuccess());
+
+        // Verify state
+        $this->assertTrue($this->thereIsALockedAssetWith($assetId1, $owner1));
+        $this->assertTrue($this->thereIsAnUnlockedAssetWith($assetId2));
+        $this->assertTrue($this->thereIsALockedAssetWith($assetId3, $owner3));
+    }
+
+    public function testOwnerCannotUnlockAssetLockedByAnotherOwner(): void
+    {
+        // given
+        $owner1 = OwnerId::of('OWNER_1');
+        $owner2 = OwnerId::of('OWNER_2');
+        $asset = $this->assetLockedBy($owner1);
+
+        // when - owner2 tries to unlock
+        $result = $this->service->unlock($asset->id(), $owner2, new DateTimeImmutable());
+
+        // then
+        $this->assertTrue($result->isFailure());
+        $this->assertTrue($this->thereIsALockedAssetWith($asset->id(), $owner1));
+    }
+
+    public function testOverdueLockHandling(): void
+    {
+        // given - asset locked by owner
+        $ownerId = OwnerId::of('OWNER_1');
+        $asset = $this->assetLockedBy($ownerId);
+
+        // when - process overdue (simulates time passing)
+        $this->service->unlockIfOverdue($asset->id());
+
+        // then - asset should be unlocked
+        $this->assertTrue($this->thereIsAnUnlockedAssetWith($asset->id()));
+    }
+}

--- a/availability/simple-availability/tests/Support/AssetAvailabilityEventsSupport.php
+++ b/availability/simple-availability/tests/Support/AssetAvailabilityEventsSupport.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Support;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetLocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetRegistered;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetUnlocked;
+use SoftwareArchetypes\Availability\SimpleAvailability\Events\AssetWithdrawn;
+use SoftwareArchetypes\Availability\SimpleAvailability\Infrastructure\EventPublisher\InMemoryDomainEventsPublisher;
+
+trait AssetAvailabilityEventsSupport
+{
+    protected InMemoryDomainEventsPublisher $eventPublisher;
+
+    protected function setupEventPublisher(): void
+    {
+        $this->eventPublisher = new InMemoryDomainEventsPublisher();
+    }
+
+    protected function assetRegisteredEventWasPublishedFor(AssetId $assetId): bool
+    {
+        foreach ($this->eventPublisher->getEventsOfType(AssetRegistered::class) as $event) {
+            if ($event->getAssetId()->equals($assetId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function assetWithdrawnEventWasPublishedFor(AssetId $assetId): bool
+    {
+        foreach ($this->eventPublisher->getEventsOfType(AssetWithdrawn::class) as $event) {
+            if ($event->getAssetId()->equals($assetId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function assetLockedEventWasPublishedFor(AssetId $assetId, OwnerId $ownerId): bool
+    {
+        foreach ($this->eventPublisher->getEventsOfType(AssetLocked::class) as $event) {
+            if ($event->getAssetId()->equals($assetId) && $event->getOwnerId()->equals($ownerId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function assetUnlockedEventWasPublishedFor(AssetId $assetId, OwnerId $ownerId): bool
+    {
+        foreach ($this->eventPublisher->getEventsOfType(AssetUnlocked::class) as $event) {
+            if ($event->getAssetId()->equals($assetId) && $event->getOwnerId()->equals($ownerId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/availability/simple-availability/tests/Support/AssetAvailabilityStoreSupport.php
+++ b/availability/simple-availability/tests/Support/AssetAvailabilityStoreSupport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Support;
 
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Clock;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailabilityRepository;
 use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
@@ -15,17 +16,18 @@ use SoftwareArchetypes\Availability\SimpleAvailability\Tests\Fixtures\AssetAvail
 trait AssetAvailabilityStoreSupport
 {
     abstract protected function getRepository(): AssetAvailabilityRepository;
+    abstract protected function getClock(): Clock;
 
     protected function existingAsset(): AssetAvailability
     {
-        $asset = AssetAvailabilityFixture::someNewAsset();
+        $asset = AssetAvailabilityFixture::someNewAsset($this->getClock());
         $this->getRepository()->save($asset);
         return $asset;
     }
 
     protected function activatedAsset(): AssetAvailability
     {
-        $asset = AssetAvailabilityFixture::create()
+        $asset = AssetAvailabilityFixture::create($this->getClock())
             ->thatIsActive()
             ->get();
         $this->getRepository()->save($asset);
@@ -34,7 +36,7 @@ trait AssetAvailabilityStoreSupport
 
     protected function assetLockedBy(OwnerId $ownerId): AssetAvailability
     {
-        $asset = AssetAvailabilityFixture::create()
+        $asset = AssetAvailabilityFixture::create($this->getClock())
             ->thatIsActive()
             ->thatWasLockedByOwnerWith($ownerId)
             ->forSomeValidDuration()
@@ -45,7 +47,7 @@ trait AssetAvailabilityStoreSupport
 
     protected function lockedAsset(): AssetAvailability
     {
-        $asset = AssetAvailabilityFixture::create()
+        $asset = AssetAvailabilityFixture::create($this->getClock())
             ->thatIsActive()
             ->thatWasLockedBySomeOwner()
             ->forSomeValidDuration()

--- a/availability/simple-availability/tests/Support/AssetAvailabilityStoreSupport.php
+++ b/availability/simple-availability/tests/Support/AssetAvailabilityStoreSupport.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Support;
+
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailability;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetAvailabilityRepository;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\AssetId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerId;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\OwnerLock;
+use SoftwareArchetypes\Availability\SimpleAvailability\Domain\WithdrawalLock;
+use SoftwareArchetypes\Availability\SimpleAvailability\Tests\Fixtures\AssetAvailabilityFixture;
+
+trait AssetAvailabilityStoreSupport
+{
+    abstract protected function getRepository(): AssetAvailabilityRepository;
+
+    protected function existingAsset(): AssetAvailability
+    {
+        $asset = AssetAvailabilityFixture::someNewAsset();
+        $this->getRepository()->save($asset);
+        return $asset;
+    }
+
+    protected function activatedAsset(): AssetAvailability
+    {
+        $asset = AssetAvailabilityFixture::create()
+            ->thatIsActive()
+            ->get();
+        $this->getRepository()->save($asset);
+        return $asset;
+    }
+
+    protected function assetLockedBy(OwnerId $ownerId): AssetAvailability
+    {
+        $asset = AssetAvailabilityFixture::create()
+            ->thatIsActive()
+            ->thatWasLockedByOwnerWith($ownerId)
+            ->forSomeValidDuration()
+            ->get();
+        $this->getRepository()->save($asset);
+        return $asset;
+    }
+
+    protected function lockedAsset(): AssetAvailability
+    {
+        $asset = AssetAvailabilityFixture::create()
+            ->thatIsActive()
+            ->thatWasLockedBySomeOwner()
+            ->forSomeValidDuration()
+            ->get();
+        $this->getRepository()->save($asset);
+        return $asset;
+    }
+
+    protected function thereIsAWithdrawnAssetWith(AssetId $id): bool
+    {
+        $asset = $this->getRepository()->findById($id);
+        if ($asset === null) {
+            return false;
+        }
+
+        $lock = $asset->currentLock();
+        return $lock instanceof WithdrawalLock;
+    }
+
+    protected function thereIsALockedAssetWith(AssetId $assetId, OwnerId $ownerId): bool
+    {
+        $asset = $this->getRepository()->findById($assetId);
+        if ($asset === null) {
+            return false;
+        }
+
+        $lock = $asset->currentLock();
+        return $lock instanceof OwnerLock && $lock->ownerId()->equals($ownerId);
+    }
+
+    protected function assetIsRegisteredWith(AssetId $assetId): bool
+    {
+        return $this->getRepository()->findById($assetId) !== null;
+    }
+
+    protected function thereIsAnUnlockedAssetWith(AssetId $assetId): bool
+    {
+        $asset = $this->getRepository()->findById($assetId);
+        if ($asset === null) {
+            return false;
+        }
+
+        return $asset->currentLock() === null;
+    }
+}

--- a/availability/simple-availability/tests/Support/MockClock.php
+++ b/availability/simple-availability/tests/Support/MockClock.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SoftwareArchetypes\Availability\SimpleAvailability\Tests\Support;
+
+use DateInterval;
+use DateTimeImmutable;
+use SoftwareArchetypes\Availability\SimpleAvailability\Common\Clock;
+
+final class MockClock implements Clock
+{
+    private DateTimeImmutable $currentTime;
+
+    public function __construct(?DateTimeImmutable $currentTime = null)
+    {
+        $this->currentTime = $currentTime ?? new DateTimeImmutable();
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->currentTime;
+    }
+
+    public function setTime(DateTimeImmutable $time): void
+    {
+        $this->currentTime = $time;
+    }
+
+    public function daysForward(int $days): self
+    {
+        $this->currentTime = $this->currentTime->add(new DateInterval("P{$days}D"));
+        return $this;
+    }
+
+    public function daysBackward(int $days): self
+    {
+        $this->currentTime = $this->currentTime->sub(new DateInterval("P{$days}D"));
+        return $this;
+    }
+
+    public function hoursForward(int $hours): self
+    {
+        $this->currentTime = $this->currentTime->add(new DateInterval("PT{$hours}H"));
+        return $this;
+    }
+
+    public function hoursBackward(int $hours): self
+    {
+        $this->currentTime = $this->currentTime->sub(new DateInterval("PT{$hours}H"));
+        return $this;
+    }
+
+    public function minutesForward(int $minutes): self
+    {
+        $this->currentTime = $this->currentTime->add(new DateInterval("PT{$minutes}M"));
+        return $this;
+    }
+
+    public function minutesBackward(int $minutes): self
+    {
+        $this->currentTime = $this->currentTime->sub(new DateInterval("PT{$minutes}M"));
+        return $this;
+    }
+}


### PR DESCRIPTION
Port of the Simple Availability archetype from Software Archetypes Java project to PHP 8.4.

Features:
- Domain-driven design with aggregate root pattern
- Event-driven architecture with domain events
- Functional error handling using Result monad
- Full type safety with PHP 8.4 readonly classes
- Lock-based availability management (Maintenance, Owner, Withdrawal locks)
- Complete test coverage with PHPUnit

Structure:
- Domain layer: AssetAvailability aggregate, value objects, locks
- Application layer: AvailabilityService orchestration
- Infrastructure: In-memory repository and event publisher implementations
- Events: 11 domain events for state changes
- Commands: 6 commands for operations

This implementation follows PHP best practices and modern standards while maintaining
the core business logic from the original Java implementation.